### PR TITLE
Add SwiftUI webtoon app sample

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "WebtoonRecordApp",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .executable(
+            name: "WebtoonRecordApp",
+            targets: ["WebtoonRecordApp"]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "WebtoonRecordApp",
+            path: "WebtoonRecordApp/Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ This repository contains a simple SwiftUI example for managing personal webtoon 
 - Support for personal ratings, studios and reading status
 
 All code is located under `WebtoonRecordApp/Sources`.
+
+### Running in Xcode
+
+1. Open `Package.swift` in Xcode (`File > Open`).
+2. Select the **WebtoonRecordApp** scheme.
+3. Choose an iOS simulator running iOS 15 or later and build.
+
+`swift build` in this environment fails because it lacks the `SwiftUI` SDK.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# personal
-my personal accaunt
+# Webtoon Record App
+
+This repository contains a simple SwiftUI example for managing personal webtoon records. The app demonstrates how you might track your favorite webtoons, rate them and view additional details.
+
+## Features
+- List of webtoons with thumbnail cards
+- Detail page with episodes, info and review tabs
+- Support for personal ratings, studios and reading status
+
+All code is located under `WebtoonRecordApp/Sources`.

--- a/WebtoonRecordApp/Sources/ContentView.swift
+++ b/WebtoonRecordApp/Sources/ContentView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var webtoons: [Webtoon] = SampleData.webtoons
+
+    var body: some View {
+        NavigationView {
+            List(webtoons) { toon in
+                NavigationLink(destination: WebtoonDetailView(webtoon: toon)) {
+                    WebtoonCardView(webtoon: toon)
+                }
+            }
+            .navigationTitle("내 웹툰")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/WebtoonRecordApp/Sources/Models.swift
+++ b/WebtoonRecordApp/Sources/Models.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+
+enum PersonalRating: String, CaseIterable, Identifiable, Codable {
+    case terrible = "졸작"
+    case average = "보통"
+    case good = "수작"
+    case great = "명작"
+    case masterpiece = "인생작품"
+
+    var id: String { rawValue }
+}
+
+enum WebtoonStatus: String, CaseIterable, Identifiable, Codable {
+    case ongoing = "연재 중"
+    case completed = "완결"
+    case hiatus = "휴재"
+
+    var id: String { rawValue }
+}
+
+struct Webtoon: Identifiable, Codable {
+    var id = UUID()
+    var title: String
+    var author: String
+    var genre: String
+    var dayOfWeek: String
+    var views: Int
+    var status: WebtoonStatus
+    var studio: String?
+    var personalRating: PersonalRating
+    var personalScore: Double
+    var thumbnail: String?
+    var episodes: [Episode]
+    var review: String = ""
+}
+
+struct Episode: Identifiable, Codable {
+    var id = UUID()
+    var title: String
+    var thumbnail: String?
+    var read: Bool = false
+}
+
+struct SampleData {
+    static let webtoons: [Webtoon] = [
+        Webtoon(title: "테스트 웹툰", author: "작가A", genre: "판타지", dayOfWeek: "월", views: 12345, status: .ongoing, studio: "캐롯툰", personalRating: .good, personalScore: 8.4, thumbnail: nil, episodes: [
+            Episode(title: "1화", thumbnail: nil),
+            Episode(title: "2화", thumbnail: nil)
+        ]),
+        Webtoon(title: "샘플 웹툰", author: "작가B", genre: "로맨스", dayOfWeek: "수", views: 54321, status: .completed, studio: "골렘팩토리", personalRating: .great, personalScore: 9.2, thumbnail: nil, episodes: [
+            Episode(title: "1화", thumbnail: nil)
+        ])
+    ]
+}

--- a/WebtoonRecordApp/Sources/WebtoonApp.swift
+++ b/WebtoonRecordApp/Sources/WebtoonApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WebtoonRecordApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/WebtoonRecordApp/Sources/WebtoonCardView.swift
+++ b/WebtoonRecordApp/Sources/WebtoonCardView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct WebtoonCardView: View {
+    let webtoon: Webtoon
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                if let imageName = webtoon.thumbnail {
+                    Image(imageName)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.2))
+                        .overlay(Text("썸네일").font(.caption).foregroundColor(.gray))
+                }
+            }
+            .frame(width: 70, height: 100)
+            .cornerRadius(8)
+            .clipped()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(webtoon.title)
+                    .font(.headline)
+                    .lineLimit(1)
+
+                Text(webtoon.author)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                HStack(spacing: 6) {
+                    Label(webtoon.personalRating.rawValue, systemImage: "star.fill")
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                    Text(webtoon.status.rawValue)
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                    if let studio = webtoon.studio {
+                        Text(studio)
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                Text("점수: \(String(format: "%.1f", webtoon.personalScore))")
+                    .font(.caption2)
+                    .foregroundColor(.blue)
+            }
+        }
+        .padding(10)
+        .background(Color(UIColor.secondarySystemBackground))
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+}

--- a/WebtoonRecordApp/Sources/WebtoonDetailView.swift
+++ b/WebtoonRecordApp/Sources/WebtoonDetailView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct WebtoonDetailView: View {
+    let webtoon: Webtoon
+    @State private var selection = 0
+
+    var body: some View {
+        VStack {
+            if let imageName = webtoon.thumbnail {
+                Image(imageName)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.2))
+                    .frame(height: 200)
+                    .overlay(Text("썸네일").font(.headline).foregroundColor(.gray))
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(webtoon.title)
+                        .font(.title3)
+                        .bold()
+                    Spacer()
+                    Text(webtoon.author)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                Text("\(webtoon.genre) | \(webtoon.dayOfWeek) | 조회수 \(webtoon.views)")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                Text("\(webtoon.status.rawValue) | \(webtoon.studio ?? "-")")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                Text("내 점수: \(String(format: "%.1f", webtoon.personalScore))")
+                    .font(.footnote)
+                    .foregroundColor(.blue)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+
+            Picker("", selection: $selection) {
+                Text("회차").tag(0)
+                Text("정보").tag(1)
+                Text("내 리뷰").tag(2)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+
+            TabView(selection: $selection) {
+                EpisodeListView(episodes: webtoon.episodes).tag(0)
+                InfoView(webtoon: webtoon).tag(1)
+                ReviewView(review: webtoon.review).tag(2)
+            }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct EpisodeListView: View {
+    let episodes: [Episode]
+    var body: some View {
+        List(episodes) { ep in
+            HStack {
+                if let imageName = ep.thumbnail {
+                    Image(imageName)
+                        .resizable()
+                        .frame(width: 50, height: 50)
+                        .cornerRadius(4)
+                } else {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(width: 50, height: 50)
+                        .overlay(Text("썸네일").font(.caption))
+                }
+                Text(ep.title)
+                Spacer()
+                if ep.read {
+                    Text("읽음").foregroundColor(.gray)
+                }
+            }
+        }
+    }
+}
+
+struct InfoView: View {
+    let webtoon: Webtoon
+    var body: some View {
+        List {
+            Section(header: Text("정보")) {
+                Label(webtoon.status.rawValue, systemImage: "book.fill")
+                if let studio = webtoon.studio { Text(studio) }
+                Text(webtoon.genre)
+                Text("연재 요일: \(webtoon.dayOfWeek)")
+                Text("조회수: \(webtoon.views)")
+            }
+        }.listStyle(GroupedListStyle())
+    }
+}
+
+struct ReviewView: View {
+    let review: String
+    var body: some View {
+        ScrollView {
+            Text(review.isEmpty ? "리뷰가 없습니다." : review)
+                .padding()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create minimal SwiftUI example under `WebtoonRecordApp`
- implement basic models, card and detail views
- update README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6882044a53f4832bb59fd7ed62608b8f